### PR TITLE
Add `tox` and Python 3.11 support

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,17 +10,18 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }} and install dependencies
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip' # caching pip dependencies
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }} and install dependencies
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip' # caching pip dependencies
+      
+    - name: Install Tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
         
-        - name: Install Tox
-          run: |
-            python -m pip install --upgrade pip
-            pip install tox
-        - name: Run Tox
-          # Run tox using the version of Python in `PATH`
-          run: tox -e py
+    - name: Run Tox
+      # Run tox using the version of Python in `PATH`
+      run: tox -e py

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,17 +10,17 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }} and install dependencies
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip' # caching pip dependencies
-      
-      - name: Install Tox
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox
-      - name: Run Tox
-        # Run tox using the version of Python in `PATH`
-        run: tox -e py
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }} and install dependencies
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip' # caching pip dependencies
+        
+        - name: Install Tox
+          run: |
+            python -m pip install --upgrade pip
+            pip install tox
+        - name: Run Tox
+          # Run tox using the version of Python in `PATH`
+          run: tox -e py

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: 
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         
     steps:
     - uses: actions/checkout@v3
@@ -16,9 +16,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip' # caching pip dependencies
-    - run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-
-    - name: Run pytest
-      run: pytest
+      
+      - name: Install Tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run Tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e py

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .coverage
 dist/
 .ruff_cache/
+.tox/

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you have feature requests, please [file an issue](https://github.com/EndlessT
 
 Please **raise an issue before making a PR**, so that the issue and implementation can be discussed before you write any code. This will save you time, and increase the chances of your PR being merged without significant changes.
 
-Please **format you code** with [Black](https://pypi.org/project/black/).
+Please **format you code** with [Black](https://pypi.org/project/black/) and [isort](https://pypi.org/project/isort/).
 
 Please **include tests** for any PR's that include code (unless current tests cover your code contribution).
 
@@ -83,15 +83,3 @@ Please **include tests** for any PR's that include code (unless current tests co
 If you would like to show your support for the project, I would be very grateful if you would donate to a charity close to my heart, [Walk AS One](https://walkasone.org/donate).
 
 And if you would prefer to donate to me personally instead, [you can sponsor me on Github](https://github.com/sponsors/EndlessTrax)? 🤓
-
-## Changelog
-
-### 2.0
-
-- Breaking changes to CLI commands
-- Added ability to add games from locally saved `.pgn` files to the output database
-
-### 1.0
-
-- Fetch games from _chess.com_ and _lichess.org_
-- Saves games to SQlite3 database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ] 
 description-file = "README.md"
 requires = [

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ flit
 pytest
 pytest-cov
 ruff
+tox
 typing_extensions==3.10.0.0 # Required for Black to run on Python < 3.10
 typed-ast>=1.4.2 # Required for Black to run on Python < 3.8
 importlib-metadata # Required for Click to run on Python < 3.8 

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ flit
 pytest
 pytest-cov
 ruff
+isort
 tox
 typing_extensions==3.10.0.0 # Required for Black to run on Python < 3.10
 typed-ast>=1.4.2 # Required for Black to run on Python < 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ colorama==0.4.6 \
     # via
     #   click
     #   pytest
+    #   tox
 coverage[toml]==6.5.0 \
     --hash=sha256:027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79 \
     --hash=sha256:11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a \
@@ -111,6 +112,10 @@ deprecated==1.2.13 \
     --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
     --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
     # via berserk
+distlib==0.3.6 \
+    --hash=sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46 \
+    --hash=sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e
+    # via virtualenv
 docutils==0.19 \
     --hash=sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6 \
     --hash=sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc
@@ -119,6 +124,12 @@ exceptiongroup==1.0.0 \
     --hash=sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41 \
     --hash=sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad
     # via pytest
+filelock==3.8.0 \
+    --hash=sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc \
+    --hash=sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4
+    # via
+    #   tox
+    #   virtualenv
 flit==3.7.1 \
     --hash=sha256:06a93a6737fa9380ba85fe8d7f28efb6c93c4f4ee9c7d00cc3375a81f33b91a4 \
     --hash=sha256:3c9bd9c140515bfe62dd938c6610d10d6efb9e35cc647fc614fe5fb3a5036682
@@ -139,6 +150,10 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
+isort==5.10.1 \
+    --hash=sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7 \
+    --hash=sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951
+    # via -r .\requirements.in
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
@@ -150,7 +165,9 @@ ndjson==0.3.1 \
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
-    # via pytest
+    # via
+    #   pytest
+    #   tox
 pathspec==0.10.1 \
     --hash=sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93 \
     --hash=sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d
@@ -158,11 +175,19 @@ pathspec==0.10.1 \
 platformdirs==2.5.2 \
     --hash=sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788 \
     --hash=sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19
-    # via black
+    # via
+    #   black
+    #   virtualenv
 pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
-    # via pytest
+    # via
+    #   pytest
+    #   tox
+py==1.11.0 \
+    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
+    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
+    # via tox
 pyparsing==3.0.9 \
     --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
     --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
@@ -202,6 +227,10 @@ ruff==0.0.86 \
     --hash=sha256:f23403f2cad4ed6a53f5c790df6b9eb936d55687cb2cc1251a39285bdb3866b9 \
     --hash=sha256:f8de9d89e9fedb272c5694bade256ca2842550845ede96480ec611bde0627373
     # via -r .\requirements.in
+six==1.16.0 \
+    --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
+    --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+    # via tox
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
@@ -210,10 +239,15 @@ tomli==2.0.1 \
     #   coverage
     #   flit
     #   pytest
+    #   tox
 tomli-w==1.0.0 \
     --hash=sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463 \
     --hash=sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9
     # via flit
+tox==3.27.0 \
+    --hash=sha256:89e4bc6df3854e9fc5582462e328dd3660d7d865ba625ae5881bbc63836a6324 \
+    --hash=sha256:d2c945f02a03d4501374a3d5430877380deb69b218b1df9b7f1d2f2a10befaf9
+    # via -r .\requirements.in
 typed-ast==1.5.4 \
     --hash=sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2 \
     --hash=sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1 \
@@ -249,6 +283,10 @@ urllib3==1.26.12 \
     --hash=sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e \
     --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
     # via requests
+virtualenv==20.16.6 \
+    --hash=sha256:186ca84254abcbde98180fd17092f9628c5fe742273c02724972a1d8a2035108 \
+    --hash=sha256:530b850b523c6449406dfba859d6345e48ef19b8439606c5d74d7d3c9e14d76e
+    # via tox
 wrapt==1.14.1 \
     --hash=sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3 \
     --hash=sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b \

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import requests
 from click.testing import CliRunner
-from pgn_to_sqlite.cli import build_pgn_dict, convert_to_snake_case, cli
+
+from pgn_to_sqlite.cli import build_pgn_dict, cli, convert_to_snake_case
 
 
 def test_snake_case_conversion():

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py37, py38, py39, py310
+isolated_build = True
+
+[testenv]
+deps = 
+    pytest
+    requests
+    click
+    pytest-cov
+commands = 
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py37, py38, py39, py310, py311
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
- Adds `tox` for testing against multiple versions of Python. 
- Support added for Python 3.11
- Minor formatting and doc edits