### PR TITLE
ci: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small configuration update to the GitHub Actions workflow. The change adds explicit permissions for the workflow to write to repository contents, which is necessary for publishing actions. 

- Added `permissions: contents: write` to the `.github/workflows/publish.yml` workflow configuration to ensure the workflow can publish releases.
