### PR TITLE
ci: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   testing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by specifying explicit permissions for the workflow.

* Added `permissions` block with `contents: read` to the `.github/workflows/run_tests.yml` file to restrict workflow permissions.
