### PR TITLE
ci: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request adds a permissions block to the GitHub Actions workflow configuration to explicitly set the permissions for the workflow.

Workflow configuration update:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R10-R12): Added a `permissions` block to specify that the workflow only requires read access to repository contents.
